### PR TITLE
Fixes #4 - Guard against stat() of NULL pointer

### DIFF
--- a/src/cronoutils.c
+++ b/src/cronoutils.c
@@ -247,11 +247,11 @@ create_link(char *pfilename,
 {
     struct stat		stat_buf;
     
-    if (stat(prevlinkname, &stat_buf) == 0)
+    if (prevlinkname && stat(prevlinkname, &stat_buf) == 0)
     {
 	unlink(prevlinkname);
     }
-    if (stat(linkname, &stat_buf) == 0)
+    if (linkname && stat(linkname, &stat_buf) == 0)
     {
 	if (prevlinkname) {
 	    rename(linkname, prevlinkname);


### PR DESCRIPTION
GCC/glibc behavior is undefined when calling stat() with a null
pathname. As a result, this code does not work properly when compiled
with GCC versions newer than somewhere around GCC-5 (exact version
unknown) when using -O2.

References:
https://bugs.launchpad.net/ubuntu/+source/gcc-5/+bug/1770676
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85778