### PR TITLE
Unlink fails when prevlinkname does't get checked properly causing li…

### DIFF
--- a/src/cronoutils.c
+++ b/src/cronoutils.c
@@ -253,7 +253,7 @@ create_link(char *pfilename,
     }
     if (stat(linkname, &stat_buf) == 0)
     {
-	if (prevlinkname) {
+	if (prevlinkname && stat(prevlinkname, &stat_buf) == 0) {
 	    rename(linkname, prevlinkname);
 	}
 	else {


### PR DESCRIPTION
…nk to fail on the next step.